### PR TITLE
add credentials options to batch

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,5 +43,6 @@
     "Blob": true,
     "Class": true,
     "window": true,
+    "$PropertyType": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Middlewares
   - `method` - string, for request method type (default: `POST`)
   - headers - Object with headers for fetch. Can be Promise or function(req).
   - credentials - string, setting for fetch method, eg. 'same-origin' (default: empty).
+  - also you may provide `mode`, `cache`, `redirect` options for fetch method, for details see [fetch spec](https://fetch.spec.whatwg.org/#requests).
 - **cacheMiddleware** - for caching same queries you may use this middleware. It will skip (do not cache) mutations and FormData requests.
   - `size` - max number of request in cache, least-recently *updated* entries purged first (default: `100`).
   - `ttl` - number in milliseconds, how long records stay valid in cache (default: `900000`, 15 minutes).
@@ -153,7 +154,7 @@ const network = new RelayNetworkLayer([
     req.fetchOpts.headers['X-Request-ID'] = uuid.v4(); // add `X-Request-ID` to request headers
     req.fetchOpts.credentials = 'same-origin'; // allow to send cookies (sending credentials to same domains)
     // req.fetchOpts.credentials = 'include'; // allow to send cookies for CORS (sending credentials to other domains)
-        
+
     console.log('RelayRequest', req);
 
     const res = await next(req);

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Middlewares
   - `batchTimeout` - integer in milliseconds, period of time for gathering multiple requests before sending them to the server. Will delay sending of the requests on specified in this option period of time, so be careful and keep this value small. (default: `0`)
   - `maxBatchSize` - integer representing maximum size of request to be sent in a single batch. Once a request hits the provided size in length a new batch request is ran. Actual for hardcoded limit in 100kb per request in [express-graphql](https://github.com/graphql/express-graphql/blob/master/src/parseBody.js#L112) module. (default: `102400` characters, roughly 100kb for 1-byte characters or 200kb for 2-byte characters)
   - `allowMutations` - by default batching disabled for mutations, you may enable it passing `true` (default: `false`)
+  - `method` - string, for request method type (default: `POST`)
+  - headers - Object with headers for fetch. Can be Promise or function(req).
+  - credentials - string, setting for fetch method, eg. 'same-origin' (default: empty).
+  - also you may provide `mode`, `cache`, `redirect` options for fetch method, for details see [fetch spec](https://fetch.spec.whatwg.org/#requests).
 - **loggerMiddleware** - for logging requests and responses.
   - `logger` - log function (default: `console.log.bind(console, '[RELAY-NETWORK]')`)
   - An example of req/res output in console: <img width="968" alt="screen shot 2017-11-19 at 23 05 19" src="https://user-images.githubusercontent.com/1946920/33159466-557517e0-d03d-11e7-9711-ebdfe6e789c8.png">

--- a/src/RelayRequestBatch.js
+++ b/src/RelayRequestBatch.js
@@ -3,24 +3,29 @@
 import type { FetchOpts, Variables } from './definition';
 import type RelayRequest from './RelayRequest';
 
-type BatchFetchOpts = {
-  credentials?: string,
-  [name: string]: mixed,
-}
-
 export type Requests = RelayRequest[];
 
 export default class RelayRequestBatch {
   fetchOpts: $Shape<FetchOpts>;
   requests: Requests;
 
-  constructor(requests: Requests, options: BatchFetchOpts) {
+  constructor(requests: Requests) {
     this.requests = requests;
     this.fetchOpts = {
       method: 'POST',
       headers: {},
       body: this.prepareBody(),
-      ...options
+    };
+  }
+
+  setFetchOption(name, value: mixed) {
+    this.fetchOpts[name] = value;
+  }
+
+  setFetchOptions(opts: Object) {
+    this.fetchOpts = {
+      ...this.fetchOpts,
+      ...opts,
     };
   }
 

--- a/src/RelayRequestBatch.js
+++ b/src/RelayRequestBatch.js
@@ -3,18 +3,24 @@
 import type { FetchOpts, Variables } from './definition';
 import type RelayRequest from './RelayRequest';
 
+type BatchFetchOpts = {
+  credentials?: string,
+  [name: string]: mixed,
+}
+
 export type Requests = RelayRequest[];
 
 export default class RelayRequestBatch {
   fetchOpts: $Shape<FetchOpts>;
   requests: Requests;
 
-  constructor(requests: Requests) {
+  constructor(requests: Requests, options: BatchFetchOpts) {
     this.requests = requests;
     this.fetchOpts = {
       method: 'POST',
       headers: {},
       body: this.prepareBody(),
+      ...options
     };
   }
 

--- a/src/definition.js
+++ b/src/definition.js
@@ -16,6 +16,11 @@ export type FetchOpts = {
   method: 'POST' | 'GET',
   headers: { [name: string]: string },
   body: string | FormData,
+  // Avaliable request modes in fetch options. For details see https://fetch.spec.whatwg.org/#requests
+  credentials?: 'same-origin' | 'include' | 'omit',
+  mode?: 'cors' | 'websocket' | 'navigate' | 'no-cors' | 'same-origin',
+  cache?: 'default' | 'no-store' | 'reload' | 'no-cache' | 'force-cache' | 'only-if-cached',
+  redirect?: 'follow' | 'error' | 'manual',
   [name: string]: mixed,
 };
 

--- a/src/middlewares/__tests__/__snapshots__/url-test.js.snap
+++ b/src/middlewares/__tests__/__snapshots__/url-test.js.snap
@@ -1,57 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`middlewares/url \`credentials\` option 1`] = `
-Object {
-  "body": "{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}}",
-  "credentials": "same-origin",
-  "headers": Object {
-    "Accept": "*/*",
-    "Content-Type": "application/json",
-  },
-  "method": "POST",
-  "url": "/credentials_url",
-}
-`;
-
-exports[`middlewares/url \`headers\` option as Object 1`] = `
-Object {
-  "body": "{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}}",
-  "headers": Object {
-    "Accept": "*/*",
-    "Content-Type": "application/json",
-    "custom-header": "123",
-  },
-  "method": "POST",
-  "url": "/headers_url",
-}
-`;
-
-exports[`middlewares/url \`headers\` option as thunk 1`] = `
-Object {
-  "body": "{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}}",
-  "headers": Object {
-    "Accept": "*/*",
-    "Content-Type": "application/json",
-    "thunk-header": "333",
-  },
-  "method": "POST",
-  "url": "/headers_thunk",
-}
-`;
-
-exports[`middlewares/url \`headers\` option as thunk with Promise 1`] = `
-Object {
-  "body": "{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}}",
-  "headers": Object {
-    "Accept": "*/*",
-    "Content-Type": "application/json",
-    "thunk-header": "as promise",
-  },
-  "method": "POST",
-  "url": "/headers_thunk_promise",
-}
-`;
-
 exports[`middlewares/url \`method\` option 1`] = `
 Object {
   "body": "{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}}",

--- a/src/middlewares/__tests__/url-test.js
+++ b/src/middlewares/__tests__/url-test.js
@@ -116,7 +116,11 @@ describe('middlewares/url', () => {
     const req = mockReq(1);
     const res = await req.execute(rnl);
     expect(res.data).toBe('PAYLOAD4');
-    expect(fetchMock.lastOptions()).toMatchSnapshot();
+    expect(fetchMock.lastOptions().headers).toEqual(
+      expect.objectContaining({
+        'custom-header': '123',
+      })
+    );
   });
 
   it('`headers` option as thunk', async () => {
@@ -140,7 +144,11 @@ describe('middlewares/url', () => {
     const req = mockReq(1);
     const res = await req.execute(rnl);
     expect(res.data).toBe('PAYLOAD5');
-    expect(fetchMock.lastOptions()).toMatchSnapshot();
+    expect(fetchMock.lastOptions().headers).toEqual(
+      expect.objectContaining({
+        'thunk-header': '333',
+      })
+    );
   });
 
   it('`headers` option as thunk with Promise', async () => {
@@ -165,7 +173,11 @@ describe('middlewares/url', () => {
     const req = mockReq(1);
     const res = await req.execute(rnl);
     expect(res.data).toBe('PAYLOAD5');
-    expect(fetchMock.lastOptions()).toMatchSnapshot();
+    expect(fetchMock.lastOptions().headers).toEqual(
+      expect.objectContaining({
+        'thunk-header': 'as promise',
+      })
+    );
   });
 
   it('`credentials` option', async () => {
@@ -187,6 +199,42 @@ describe('middlewares/url', () => {
     const req = mockReq(1);
     const res = await req.execute(rnl);
     expect(res.data).toBe('PAYLOAD6');
-    expect(fetchMock.lastOptions()).toMatchSnapshot();
+    expect(fetchMock.lastOptions()).toEqual(
+      expect.objectContaining({
+        credentials: 'same-origin',
+      })
+    );
+  });
+
+  it('other fetch options', async () => {
+    fetchMock.mock({
+      matcher: '/fetch',
+      response: {
+        status: 200,
+        body: { data: 'PAYLOAD7' },
+      },
+      method: 'POST',
+    });
+
+    const rnl = new RelayNetworkLayer([
+      urlMiddleware({
+        url: '/fetch',
+        credentials: 'include',
+        mode: 'cors',
+        cache: 'no-store',
+        redirect: 'follow',
+      }),
+    ]);
+    const req = mockReq(1);
+    const res = await req.execute(rnl);
+    expect(res.data).toBe('PAYLOAD7');
+    expect(fetchMock.lastOptions()).toEqual(
+      expect.objectContaining({
+        credentials: 'include',
+        mode: 'cors',
+        cache: 'no-store',
+        redirect: 'follow',
+      })
+    );
   });
 });

--- a/src/middlewares/url.js
+++ b/src/middlewares/url.js
@@ -3,7 +3,7 @@
 
 import { isFunction } from '../utils';
 import type RelayRequest from '../RelayRequest';
-import type { Middleware } from '../definition';
+import type { Middleware, FetchOpts } from '../definition';
 
 type Headers = { [name: string]: string };
 
@@ -11,11 +11,15 @@ export type UrlMiddlewareOpts = {
   url: string | Promise<string> | ((req: RelayRequest) => string | Promise<string>),
   method?: 'POST' | 'GET',
   headers?: Headers | Promise<Headers> | ((req: RelayRequest) => Headers | Promise<Headers>),
-  credentials?: 'same-origin' | string,
+  // Avaliable request modes in fetch options. For details see https://fetch.spec.whatwg.org/#requests
+  credentials?: $PropertyType<FetchOpts, 'credentials'>,
+  mode?: $PropertyType<FetchOpts, 'mode'>,
+  cache?: $PropertyType<FetchOpts, 'cache'>,
+  redirect?: $PropertyType<FetchOpts, 'redirect'>,
 };
 
 export default function urlMiddleware(opts?: UrlMiddlewareOpts): Middleware {
-  const { url, headers, method = 'POST', credentials } = opts || {};
+  const { url, headers, method = 'POST', credentials, mode, cache, redirect } = opts || {};
   const urlOrThunk: any = url || '/graphql';
   const headersOrThunk: any = headers;
 
@@ -28,13 +32,11 @@ export default function urlMiddleware(opts?: UrlMiddlewareOpts): Middleware {
         : headersOrThunk);
     }
 
-    if (method) {
-      req.fetchOpts.method = method;
-    }
-
-    if (credentials) {
-      req.fetchOpts.credentials = credentials;
-    }
+    if (method) req.fetchOpts.method = method;
+    if (credentials) req.fetchOpts.credentials = credentials;
+    if (mode) req.fetchOpts.mode = mode;
+    if (cache) req.fetchOpts.cache = cache;
+    if (redirect) req.fetchOpts.redirect = redirect;
 
     return next(req);
   };


### PR DESCRIPTION
As discussed on https://github.com/nodkz/react-relay-network-modern/issues/15.

- add `credentials` option to batch middleware
- add `options: BatchFetchOpts` to RelayRequestBatch and spread it to fetchOpts