### PR TITLE
update cache middleware to respect cacheConfig

### DIFF
--- a/src/middlewares/cache.js
+++ b/src/middlewares/cache.js
@@ -31,6 +31,10 @@ export default function queryMiddleware(opts?: CacheMiddlewareOpts): Middleware 
     if (req.isFormData() && !allowFormData) {
       return next(req);
     }
+    
+    if (req.cacheConfig && req.cacheConfig.force) {
+      return next(req);
+    }
 
     try {
       const queryId = req.getID();


### PR DESCRIPTION
The cacheConfig object (which is optional) can provide a flag to force refetches when a caching middleware is in place.

The config is used on QueryRenderers:
https://github.com/facebook/relay/blob/master/packages/react-relay/modern/ReactRelayQueryRenderer.js#L54

And in the options for a refetch inside a refetch container:
https://facebook.github.io/relay/docs/en/refetch-container.html#refetch