### PR TITLE
Add flag to enable the caching of forced requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Middlewares
   - `allowMutations` - allow to cache Mutation requests (default: `false`)
   - `allowFormData` - allow to cache FormData requests (default: `false`)
   - `clearOnMutation` - clear the cache on any Mutation (default: `false`)
-  - `cacheForcedRequests` - allow to cache the responses from forced requests, forced requests never read from the cache. (default: `false`)
 - **authMiddleware** - for adding auth token, and refreshing it if gets 401 response from server.
   - `token` - string which returns token. Can be function(req) or Promise. If function is provided, then it will be called for every request (so you may change tokens on fly).
   - `tokenRefreshPromise`: - function(req, res) which must return promise or regular value with a new token. This function is called when server returns 401 status code. After receiving a new token, middleware re-run query to the server seamlessly for Relay.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Middlewares
   - `allowMutations` - allow to cache Mutation requests (default: `false`)
   - `allowFormData` - allow to cache FormData requests (default: `false`)
   - `clearOnMutation` - clear the cache on any Mutation (default: `false`)
+  - `cacheForcedRequests` - allow to cache the responses from forced requests, forced requests never read from the cache. (default: `false`)
 - **authMiddleware** - for adding auth token, and refreshing it if gets 401 response from server.
   - `token` - string which returns token. Can be function(req) or Promise. If function is provided, then it will be called for every request (so you may change tokens on fly).
   - `tokenRefreshPromise`: - function(req, res) which must return promise or regular value with a new token. This function is called when server returns 401 status code. After receiving a new token, middleware re-run query to the server seamlessly for Relay.

--- a/src/middlewares/cache.js
+++ b/src/middlewares/cache.js
@@ -11,11 +11,10 @@ type CacheMiddlewareOpts = {|
   allowMutations?: boolean,
   allowFormData?: boolean,
   clearOnMutation?: boolean,
-  cacheForcedRequests?: boolean,
 |};
 
 export default function queryMiddleware(opts?: CacheMiddlewareOpts): Middleware {
-  const { size, ttl, onInit, allowMutations, allowFormData, clearOnMutation, cacheForcedRequests } = opts || {};
+  const { size, ttl, onInit, allowMutations, allowFormData, clearOnMutation } = opts || {};
   const cache = new QueryResponseCache({
     size: size || 100, // 100 requests
     ttl: ttl || 15 * 60 * 1000, // 15 minutes
@@ -40,14 +39,10 @@ export default function queryMiddleware(opts?: CacheMiddlewareOpts): Middleware 
     }
 
     if (req.cacheConfig && req.cacheConfig.force) {
-      if (cacheForcedRequests) {
-        const res = await next(req);
-        cache.set(queryId, variables, res);
+      const res = await next(req);
+      cache.set(queryId, variables, res);
 
-        return res;
-      } else {
-        return next(req);
-      }
+      return res;
     }
 
     try {

--- a/src/middlewares/cache.js
+++ b/src/middlewares/cache.js
@@ -39,9 +39,11 @@ export default function queryMiddleware(opts?: CacheMiddlewareOpts): Middleware 
     }
 
     if (req.cacheConfig && req.cacheConfig.force) {
+      const queryId = req.getID();
+      const variables = req.getVariables();
       const res = await next(req);
-      cache.set(queryId, variables, res);
 
+      cache.set(queryId, variables, res);
       return res;
     }
 


### PR DESCRIPTION
It makes sense to avoid pulling from the cache for forced requests, but sometimes we want to configure the network layer to cache the response from forced requests.  This especially makes sense when we force a refresh on a page or screen, then navigate away from the screen and the component becomes unmounted. When someone returns to that screen, the QueryRenderer runs again, but this time it is not a forced request and the screen winds up fetching stale information.